### PR TITLE
Removed Session clear on step five to ValidateToken

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/Controllers/RegistrationController.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Controllers/RegistrationController.cs
@@ -230,18 +230,14 @@ namespace HelpMyStreetFE.Controllers
 
         [HttpGet("[controller]/stepfive")]
         public async Task<IActionResult> StepFive()
-        {
- 
-
+        { 
             var userId = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier).Value;
             string correctPage = await GetCorrectPage(int.Parse(userId));
             if (correctPage != "/registration/stepfive")
             {
                 // A different step needs to be completed at this point
                 return Redirect(correctPage);
-            }
-            // remove user from session (which is created from login on step one) so on profile load it can go load the user with the updated values
-            HttpContext.Session.Remove("User");
+            }     
             var viewModel = new RegistrationViewModel { ActiveStep = 5, EncodedUserID = Base64Helpers.Base64Encode(userId) };
             return View(viewModel);
         }

--- a/HelpMyStreetFE/HelpMyStreetFE/Controllers/YotiController.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Controllers/YotiController.cs
@@ -58,12 +58,14 @@ namespace HelpMyStreetFE.Controllers
         [AllowAnonymous]
         [HttpGet]
         public async Task<IActionResult> ValidateToken(string token, string u, CancellationToken cancellationToken)
-        {
+        {     
             var validUserId = DecodedAndCheckedUserId(u, token != null);
 
             if (validUserId != null && token != null)
             {
-                User user = await _userService.GetUserAsync(int.Parse(validUserId));
+                // Remove any references to User in session so on next Load it fetches the updated values;
+                HttpContext.Session.Remove("User"); 
+                User user = await _userService.GetUserAsync(int.Parse(validUserId));         
                 string correctPage = RegistrationController.GetCorrectPage(user);
                 if (correctPage != "/registration/stepfive")
                 {
@@ -75,7 +77,7 @@ namespace HelpMyStreetFE.Controllers
                 if (response.Status == ValidationStatus.Success)
                 {
                     await _userService.CreateUserStepFiveAsync(int.Parse(validUserId), true);
-
+                    
                     if (HttpContext.User.FindFirst(ClaimTypes.NameIdentifier) == null)
                     {
                         // User has switched browser during mobile Yoti app flow; they're now Yoti authenticated; log them in

--- a/HelpMyStreetFE/HelpMyStreetFE/Views/Yoti/Authenticate.cshtml
+++ b/HelpMyStreetFE/HelpMyStreetFE/Views/Yoti/Authenticate.cshtml
@@ -2,7 +2,7 @@
 
 @{
     ViewData["Title"] = "Authenticate";
-        Layout = "~/Views/Shared/_LayoutNoHeader.cshtml";
+    Layout = "~/Views/Shared/_LayoutNoHeader.cshtml";
 }
 
 @section Scripts {


### PR DESCRIPTION
Scenario: Log in on Default Browser Mobile ; Do a registration journey on a different browser; Yoti opens and redirects to their default browser; upon login the initial person is still logged in rather than newly created one. 

Solution: Clear Session when we validate the token 

