### PR TITLE
Added redirect to Yoti/Authenticate

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/Controllers/YotiController.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Controllers/YotiController.cs
@@ -64,6 +64,7 @@ namespace HelpMyStreetFE.Controllers
                     {
                         // User has switched browser during mobile Yoti app flow; they're now Yoti authenticated; log them in
                         await _authService.LoginWithUserId(int.Parse(validUserId), HttpContext);
+                        return Redirect("/account");
                     }
                 }
                 return handleValidationTokenResponse(response);

--- a/HelpMyStreetFE/HelpMyStreetFE/Views/Account/_ComingSoon.cshtml
+++ b/HelpMyStreetFE/HelpMyStreetFE/Views/Account/_ComingSoon.cshtml
@@ -15,24 +15,24 @@
                     If you are a Street Champion:
                 </p>
                 <ul>
-                    <li>You will now be able to see contact details of other Street Champions and Helpers close by on the "My Streets" tab.</li>
-                    <li>When there is a "Request for Help" you will be automatically emailed with details of what is needed.</li>
+                    <li>You will now be able to see contact details of other Street Champions and Helpers close by on the "My Streets" tab</li>
+                    <li>When there is a "Request for Help" you will be automatically emailed with details of what is needed</li>
                 </ul>
 
                 <p>
                     If you are a Helper:
                 </p>
                 <ul>
-                    <li>A Street Champion may get in touch with you to introduce themselves.</li>
-                    <li>A Street Champion might get in touch with you to help with a relevant task that needs doing.</li>
+                    <li>A Street Champion may get in touch with you to introduce themselves</li>
+                    <li>A Street Champion might get in touch with you to help with a relevant task that needs doing</li>
                 </ul>
 
                 <p>
                     We will shortly be improving the platform:
                 </p>
                 <ul>
-                    <li>We'll be adding more maps features to help everyone visualise where volunteers (our collective name for Street Champions and Helpers) are and where people in need are.</li>
-                    <li>We'll be adding more automated task management, so that volunteers will be able to see the list of work that needs completing and will be able to pick a task to complete.</li>
+                    <li>We'll be adding more maps features to help everyone visualise where volunteers (our collective name for Street Champions and Helpers) are and where people in need are</li>
+                    <li>We'll be adding more automated task management, so that volunteers will be able to see the list of work that needs completing and will be able to pick a task to complete</li>
                 </ul>
 
                 <p>Finally – please tell us what you’d like this platform to do for you by sending us your ideas to <a href="mailto:feedback@helpmystreet.org">feedback@helpmystreet.org</a>.</p>
@@ -47,24 +47,24 @@
                     Once you are a verified Street Champion:
                 </p>
                 <ul>
-                    <li>You will be able to see contact details of other Street Champions and Helpers close by on the "My Streets" tab.</li>
-                    <li>When there is a "Request for Help" you will be automatically emailed with details of what is needed.</li>
+                    <li>You will be able to see contact details of other Street Champions and Helpers close by on the "My Streets" tab</li>
+                    <li>When there is a "Request for Help" you will be automatically emailed with details of what is needed</li>
                 </ul>
 
                 <p>
                     Once you are a verified Helper:
                 </p>
                 <ul>
-                    <li>A Street Champion will be able to get in touch with you to introduce themselves.</li>
-                    <li>A Street Champion will be able to get in touch with you to help with a relevant task that needs doing.</li>
+                    <li>A Street Champion will be able to get in touch with you to introduce themselves</li>
+                    <li>A Street Champion will be able to get in touch with you to help with a relevant task that needs doing</li>
                 </ul>
 
                 <p>
                     We will shortly be improving the platform:
                 </p>
                 <ul>
-                    <li>We'll be adding more maps features to help everyone visualise where volunteers (our collective name for Street Champions and Helpers) are and where people in need are.</li>
-                    <li>We'll be adding more automated task management, so that volunteers will be able to see the list of work that needs completing and will be able to pick a task to complete.</li>
+                    <li>We'll be adding more maps features to help everyone visualise where volunteers (our collective name for Street Champions and Helpers) are and where people in need are</li>
+                    <li>We'll be adding more automated task management, so that volunteers will be able to see the list of work that needs completing and will be able to pick a task to complete</li>
                 </ul>
 
                 <p>Finally – please tell us what you’d like this platform to do for you by sending us your ideas to <a href="mailto:feedback@helpmystreet.org">feedback@helpmystreet.org</a>.</p>

--- a/HelpMyStreetFE/HelpMyStreetFE/src/js/yoti.js
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/js/yoti.js
@@ -1,28 +1,3 @@
-
-
-$(() => {
-    var getParameterByName = function (name, url) {
-        if (!url) url = window.location.href;
-        name = name.replace(/[\[\]]/g, '\\$&');
-        var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
-            results = regex.exec(url);
-        if (!results) return null;
-        if (!results[2]) return '';
-        return decodeURIComponent(results[2].replace(/\+/g, ' '));
-    }
-
-    var urlToken = getParameterByName("token");
-    var userId = getParameterByName("u");
-    if (initObj) {
-        if (urlToken) {
-            processYoti(urlToken, userId)
-        }                  
-    }else {
-            throw new Error("initObj is null");
-        }    
-});
-
-
 var processYoti = async function (thisToken, userId) {
     $('#overlay').show();
     $('.loading-overlay').show();


### PR DESCRIPTION
Currently, the code for validating the token lives inside the account page so when navigating from a different browser, you're confronted with a login screen which messes up the journey 
in order for the mobile swap journey to work, i have to point the Yoti hub to this method and added a redirect in the method.

also removed full stops from the coming soon page after bullet points. 

