### PR TITLE
Hide Address finder when requesting on behalf

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/Controllers/RequestHelpController.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Controllers/RequestHelpController.cs
@@ -43,7 +43,7 @@ namespace HelpMyStreetFE.Controllers
             if (onBehalf)
             {
                 message += "<p>Are you Volunteering in your local area? Sign up as a Street Champion or Helper to help and support local people shelter safely at home </p>";
-                button = " <a href='/registration/step-one' class='btn cta large fill mt16 btn--sign-up '>Sign up</a>";
+                button = " <a href='/registration/stepone' class='btn cta large fill mt16 btn--sign-up '>Sign up</a>";
             }
 
             List<NotificationModel> notifications = new List<NotificationModel> {

--- a/HelpMyStreetFE/HelpMyStreetFE/Views/RequestHelp/DetailStage/_UserDetails.cshtml
+++ b/HelpMyStreetFE/HelpMyStreetFE/Views/RequestHelp/DetailStage/_UserDetails.cshtml
@@ -34,7 +34,8 @@
         </div>
         <div class="input sm3">
             <label>@Model.LabelPrefix postcode</label>
-            <input name="postcode_search_@Model.NamePostfix" type="text" placeholder="e.g. NG1 1PS" />            
+            <input name="postcode_search_@Model.NamePostfix" type="text" placeholder="e.g. NG1 1PS" />
+            <span id="e-postcode_search_@Model.NamePostfix" class="error"></span>
         </div>
         <div class="input sm3 find-address">
             <button class="btn large border-blue blue fill" id="address_finder_@Model.NamePostfix">

--- a/HelpMyStreetFE/HelpMyStreetFE/Views/RequestHelp/RequestStage/_RequestFor.cshtml
+++ b/HelpMyStreetFE/HelpMyStreetFE/Views/RequestHelp/RequestStage/_RequestFor.cshtml
@@ -30,9 +30,9 @@
             <div class="sm4">
                 <div id="someone-else" data-type="request-for" class="tiles__tile tiles__tile--large dark-blue">
                     <div class="tiles__tile__content ">
-                        <div class="tiles__tile__content__icon">
-                            <div class="cirlce">
-                                <img class="no-selected" src="~/img/icons/request-behalf.svg" />
+                        <div class="tiles__tile__content__icon ">
+                            <div class="cirlce double-line-alignment">
+                                <img class="no-selected " src="~/img/icons/request-behalf.svg" />
                                 <img class="on-selected" src="~/img/icons/request-behalf-white.svg" />
                             </div>
                         </div>

--- a/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/detail-stage.js
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/detail-stage.js
@@ -241,7 +241,7 @@ var validateAddress = async function (obj, expanderPostfix) {
         valid = false;
     } else {
         buttonLoad($('#btnNext'))
-        var postcodeValid = await _validatePostcode(obj.address.postcode.val);
+        var postcodeValid = await validatePostCode(obj.address.postcode.val);
         if (!postcodeValid) {
             valid = false;
             $('#' + obj.address.postcode.errorSpan).show().text("Please enter a valid UK postcode");
@@ -254,18 +254,6 @@ var validateAddress = async function (obj, expanderPostfix) {
 
 
 
-var _validatePostcode = async function (postcode) {
-    let postcodeValid = true;
-    try {
-        let validPostcode = await validatePostCode(postcode)
-        if (!validPostcode) {
-            postcodeValid = false;
-        }
-    } catch  {
-        postcodeValid = false;
-    }
-    return postcodeValid;
-}
 
 var validateYourDetails = async function (onBehalf) {
     let valid = true;
@@ -283,7 +271,7 @@ var validateYourDetails = async function (onBehalf) {
         if (!await validateAddress(detailStage.yourDetails, "your"))
             valid = false;
     } else {
-        if (!await _validatePostcode(detailStage.yourDetails.address.postcode.val)) {
+        if (!await validatePostCode(detailStage.yourDetails.address.postcode.val)) {
             valid = false;
             $('#e-postcode_search_your').show().text("Please enter a valid UK postcode");
         }

--- a/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/detail-stage.js
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/detail-stage.js
@@ -36,7 +36,7 @@ export var detailStage = {
     validate: async function (requestFor) {
         let onBehalf = requestFor.val == "someone-else" ? true : false;
         $('.error').hide();
-        let valid = await validateYourDetails();
+        let valid = await validateYourDetails(onBehalf);
         if (detailStage.consentForContact.val == false) {
             $('#' + detailStage.consentForContact.errorSpan).show().text("Please check to confirm that you have read and understood this");
             valid = false;
@@ -56,17 +56,36 @@ export function initaliseDetailStage(requestFor) {
     intialiseConsentForContact();
     if (detailStage.onBehalf == true) {
         $('#their-details').show();
-        initaliseAddressFinder("their", detailStage.theirDetails);
-        initaliseAddressFinder("your", detailStage.yourDetails);
+        initaliseAddressFinder("their", detailStage.theirDetails, false);
+        initaliseAddressFinder("your", detailStage.yourDetails, true);
+        HideorShowFindAddress(true, "your")
         intialiseFormFields("their", detailStage.theirDetails);
         intialiseFormFields("your", detailStage.yourDetails);        
     } else {
-        initaliseAddressFinder("your", detailStage.yourDetails);
+        HideorShowFindAddress(false, "your")
+        initaliseAddressFinder("your", detailStage.yourDetails, false);
         intialiseFormFields("your", detailStage.yourDetails); 
     } 
 }
 
+var HideorShowFindAddress = function(hide, postfix){
+    if (hide) {
+        let inputClassforPostcodeSearch = $('input[name="postcode_search_' + postfix + '"]').parent();
+        inputClassforPostcodeSearch.removeClass("sm3");
+        inputClassforPostcodeSearch.addClass("sm6");
+        let inputClassforAddressFine = $('#address_finder_' + postfix + '').parent();
+        inputClassforAddressFine.addClass("dnone");
+    } else {
+        let inputClassforPostcodeSearch = $('input[name="postcode_search_' + postfix + '"]').parent();
+        inputClassforPostcodeSearch.addClass("sm3");
+        inputClassforPostcodeSearch.removeClass("sm6");
+        let inputClassforAddressFine = $('#address_finder_' + postfix + '').parent();
+        inputClassforAddressFine.removeClass("dnone");
+    }
 
+
+
+}
 
 var intialiseFormFields = function (postfix, obj) {
     $('input[name="first_name_' + postfix + '"]').blur(function () {
@@ -87,7 +106,7 @@ var intialiseFormFields = function (postfix, obj) {
 
 }
 
-var initaliseAddressFinder = function (postfix, obj) {
+var initaliseAddressFinder = function (postfix, obj, bindPostcodeSearch) {
 
     $('input[name="address_line_1_' + postfix + '"]').blur(function () {
         obj.address.addressLine1.val = $(this).val();
@@ -101,10 +120,16 @@ var initaliseAddressFinder = function (postfix, obj) {
     $('input[name="county_' + postfix + '"]').blur(function () {
         obj.address.county.val = $(this).val();
     });
-    
-    $('input[name="postcode_' + postfix + '"]').blur(function () {
-        obj.address.postcode.val = $(this).val();
-    });
+
+    if (!bindPostcodeSearch) {
+        $('input[name="postcode_' + postfix + '"]').blur(function () {
+            obj.address.postcode.val = $(this).val();
+        });
+    } else {        
+        $('input[name="postcode_search_' + postfix + '"]').blur(function () {
+            obj.address.postcode.val = $(this).val();
+        });
+    }
 
     $('.manual-entry').click(function () {
         $("#expander_" + postfix).slideDown();
@@ -215,26 +240,34 @@ var validateAddress = async function (obj, expanderPostfix) {
         $("#expander_" + expanderPostfix).slideDown();
         valid = false;
     } else {
-        try {
-            buttonLoad($('#btnNext'))
-            let validPostcode = await validatePostCode(obj.address.postcode.val)
-            if (!validPostcode) {
-                valid = false;
-                $('#' + obj.address.postcode.errorSpan).show().text("Please enter a valid UK postcode");
-                $("#expander_" + expanderPostfix).slideDown();
-            }
-        } catch  {
-            $('#' + obj.address.postcode.errorSpan).show().text("an error occured trying to validate your postcode, please try again.");
+        buttonLoad($('#btnNext'))
+        var postcodeValid = await _validatePostcode(obj.address.postcode.val);
+        if (!postcodeValid) {
             valid = false;
-        } finally {
-            buttonUnload($('#btnNext'));
+            $('#' + obj.address.postcode.errorSpan).show().text("Please enter a valid UK postcode");
+            $("#expander_" + expanderPostfix).slideDown();
         }
-
+        buttonUnload($('#btnNext'));
     }
     return valid;
 }
 
-var validateYourDetails = async function () {
+
+
+var _validatePostcode = async function (postcode) {
+    let postcodeValid = true;
+    try {
+        let validPostcode = await validatePostCode(postcode)
+        if (!validPostcode) {
+            postcodeValid = false;
+        }
+    } catch  {
+        postcodeValid = false;
+    }
+    return postcodeValid;
+}
+
+var validateYourDetails = async function (onBehalf) {
     let valid = true;
 
     if (!validatePersonalDetails(detailStage.yourDetails))
@@ -244,8 +277,17 @@ var validateYourDetails = async function () {
         $('#' + detailStage.yourDetails.email.errorSpan).show().text("Please enter a valid email address");
         valid = false;
     }
-    if (!await validateAddress(detailStage.yourDetails, "your"))
-        valid = false;
+
+    // if they have requested for somoene else, they dont need to find their address. they just need to enter a postcode
+    if (onBehalf == false) {
+        if (!await validateAddress(detailStage.yourDetails, "your"))
+            valid = false;
+    } else {
+        if (!await _validatePostcode(detailStage.yourDetails.address.postcode.val)) {
+            valid = false;
+            $('#e-postcode_search_your').show().text("Please enter a valid UK postcode");
+        }
+    }
 
     return valid;
 }

--- a/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/requesthelp.js
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/js/requesthelp/requesthelp.js
@@ -167,7 +167,7 @@ var intialiseSubmit = function () {
                     if (respData.content.fulfillable == 4 || respData.content.fulfillable == 5 || respData.content.fulfillable == 6 || respData.content.fulfillable == 2 ) {
                         window.location.href = "/requesthelp/success?fulfillable=" + respData.content.fulfillable + "&onBehalf=" + detailStage.onBehalf;
                     } else if (respData.content.fulfillable == 1 || respData.content.fulfillable == 3) {
-                        throw 'The Request for helphad an error, this could be due to an invalid postcodee';
+                        throw 'The Request for help had an error, this could be due to an invalid postcodee';
                     }
                 } else {
                     throw 'error occured from within the request service';


### PR DESCRIPTION
Requirement :-  When requesting on behalf of someone, we don't need to capture the requestors full address, we only need their postcode. 

Solution: if on behalf, bind the postcode object to a the postcode search box; hide the find address button and only validate their postcode only. 