### PR TITLE
safari fixes

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/Services/RequestService.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Services/RequestService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
+using HelpMyStreet.Utils.Utils;
 namespace HelpMyStreetFE.Services
 {
     public class RequestService : IRequestService
@@ -48,7 +48,7 @@ namespace HelpMyStreetFE.Services
                             AddressLine1 = viewModel.HelpRequest.Recipient.Address.Addressline1,
                             AddressLine2 = viewModel.HelpRequest.Recipient.Address.Addressline2,
                             Locality = viewModel.HelpRequest.Recipient.Address.Locality,
-                            Postcode = viewModel.HelpRequest.Recipient.Address.Postcode,
+                            Postcode = PostcodeFormatter.FormatPostcode(viewModel.HelpRequest.Recipient.Address.Postcode),
                         }
                     },
                     Requestor = new RequestPersonalDetails
@@ -63,7 +63,7 @@ namespace HelpMyStreetFE.Services
                             AddressLine1 = viewModel.HelpRequest.Requestor.Address.Addressline1,
                             AddressLine2 = viewModel.HelpRequest.Requestor.Address.Addressline2,
                             Locality = viewModel.HelpRequest.Requestor.Address.Locality,
-                            Postcode = viewModel.HelpRequest.Requestor.Address.Postcode,
+                            Postcode = PostcodeFormatter.FormatPostcode(viewModel.HelpRequest.Requestor.Address.Postcode),
                         }
                     }
                 },

--- a/HelpMyStreetFE/HelpMyStreetFE/src/sass/components/_progress-bar.scss
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/sass/components/_progress-bar.scss
@@ -95,6 +95,7 @@
     z-index: 2;
     border-width: 8px;
     border-top-style: solid;
+    -webkit-border-after: 0px;
     
 }
 
@@ -120,7 +121,7 @@
 
 .progress-bar .is-complete:last-child:after,
 .progress-bar .is-active:last-child:after {
-    width: 200%;
+    width: 193%;
     left: -100%;
 }
 

--- a/HelpMyStreetFE/HelpMyStreetFE/src/sass/components/tiles/_tiles.scss
+++ b/HelpMyStreetFE/HelpMyStreetFE/src/sass/components/tiles/_tiles.scss
@@ -23,6 +23,7 @@
 
         &--large {
             min-height: 200px;
+            height:200px;
             padding: 0px;
         }
 


### PR DESCRIPTION
The progress bar was really thick in safari - Setting the -webkit-border-after: to 0px fixed it and didnt affect chrome,IE and firefox . 

Also includes a fix  for firefox. Min heights weren't being implemented.  i had to add a height property for it to be used. 