### PR TITLE
FE-309 White spinners for darker backgrounds

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/wwwroot/img/loading_spinner-white.svg
+++ b/HelpMyStreetFE/HelpMyStreetFE/wwwroot/img/loading_spinner-white.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1070 1098" width="32" height="32">
+<defs>
+  <style>
+    .circle-white {
+      fill: #fff;
+      opacity: 0.7;
+    }
+
+    .circle-white__group {
+      animation-name: spinny;
+      transform-origin: center;
+      animation-timing-function: linear;
+      animation-iteration-count: infinite;
+    }
+
+    .circle-white__group-1 {
+      animation-duration: 2.0s;
+    }
+
+    .circle-white__group-2 {
+      animation-duration: 1.0s;
+    }
+
+    .circle-white__group-3 {
+      animation-duration: 1.5s;
+    }
+
+    @keyframes spinny {
+      from {
+        transform: rotate(0deg);
+      }
+
+      to {
+        transform: rotate(360deg);
+      }
+        }
+      </style>
+    </defs>
+    <g class="circle-white__group circle-white__group-1">
+      <circle cx="360" cy="235" r="170" class="circle-white" />
+      <circle cx="530" cy="600" r="230" class="circle-white" />
+    </g>
+
+    <g class="circle-white__group circle-white__group-2">
+      <circle cx="330" cy="390" r="100" class="circle-white" />
+      <circle cx="630" cy="290" r="180" class="circle-white" />
+    </g>
+
+    <g class="circle-white__group circle-white__group-3">
+      <circle cx="210" cy="600" r="170" class="circle-white" />
+      <circle cx="650" cy="690" r="130" class="circle-white" />
+    </g>
+  </svg>


### PR DESCRIPTION
Ideally I would suggest moving the SVG inline so we can have one component that inherits the colour from its parent so it can be controlled using CSS. 

For now, this is just a separate image with white circles that should look better on the green / orange buttons, so use wherever it suits.