### PR TITLE
modified journey of coming in to DIY not authenticated

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/Controllers/RequestHelpController.cs
+++ b/HelpMyStreetFE/HelpMyStreetFE/Controllers/RequestHelpController.cs
@@ -189,7 +189,7 @@ namespace HelpMyStreetFE.Controllers
         {
             _logger.LogInformation("request-help");
             if (source == RequestHelpSource.DIY && !User.Identity.IsAuthenticated)
-                source = RequestHelpSource.Default;
+                return Redirect("/login?ReturnUrl=request-help/diy");
 
             var model = await _requestService.GetRequestHelpSteps(source);
             return View(model);


### PR DESCRIPTION
Taking users to login page with return url  - previously it directed you to the original request help form, but this was confusing for when someone clicked "Log Request" but there session had expired.