### PR TITLE
Automatic update of Microsoft.EntityFrameworkCore.SqlServer to 5.0.0-rc.1.20451.13

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0-preview1.19506.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0-preview1.19506.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.SqlServer` to `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`
`Microsoft.EntityFrameworkCore.SqlServer 5.0.0-rc.1.20451.13` was published at `2020-09-14T14:43:24Z`, 9 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`

[Microsoft.EntityFrameworkCore.SqlServer 5.0.0-rc.1.20451.13 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/5.0.0-rc.1.20451.13)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
