### PR TITLE
Automatic update of Microsoft.Extensions.Logging.Debug to 5.0.0-rc.1.20451.14

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0-preview1.19506.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
     <PackageReference Include="NewRelic.Agent" Version="8.29.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Logging.Debug` to `5.0.0-rc.1.20451.14` from `3.1.0-preview1.19506.1`
`Microsoft.Extensions.Logging.Debug 5.0.0-rc.1.20451.14` was published at `2020-09-14T14:44:06Z`, 9 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.Extensions.Logging.Debug` `5.0.0-rc.1.20451.14` from `3.1.0-preview1.19506.1`

[Microsoft.Extensions.Logging.Debug 5.0.0-rc.1.20451.14 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Debug/5.0.0-rc.1.20451.14)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
