### PR TITLE
Automatic update of 15 packages

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 

--- a/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE.UnitTests/HelpMyStreetFE.UnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0-preview1.19506.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0-rc.1.20451.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="HelpMyStreet.Cache" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.363" />
-    <PackageReference Include="MediatR" Version="8.0.1" />
+    <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.363" />
     <PackageReference Include="MediatR" Version="8.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0-rc.1.20451.13">

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0-preview1.19506.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
     <PackageReference Include="NewRelic.Agent" Version="8.29.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
-    <PackageReference Include="SendGrid" Version="9.13.2" />
+    <PackageReference Include="SendGrid" Version="9.21.0" />
 	<PackageReference Include="Polly" Version="7.2.1" />
 	<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.8" />
   </ItemGroup>

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.363" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0-rc.1.20451.13">
       <PrivateAssets>all</PrivateAssets>

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
     <PackageReference Include="SendGrid" Version="9.13.2" />
-	<PackageReference Include="Polly" Version="7.2.0" />
+	<PackageReference Include="Polly" Version="7.2.1" />
 	<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
   </ItemGroup>
 

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Polly.Contrib.DuplicateRequestCollapser" Version="0.2.1" />
     <PackageReference Include="SendGrid" Version="9.13.2" />
 	<PackageReference Include="Polly" Version="7.2.1" />
-	<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
+	<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -35,7 +35,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.1.20451.14" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
     <PackageReference Include="NewRelic.Agent" Version="8.29.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FirebaseAdmin" Version="1.9.2" />
+    <PackageReference Include="FirebaseAdmin" Version="1.16.0" />
     <PackageReference Include="HelpMyStreet.Cache" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.363" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
     <PackageReference Include="NewRelic.Agent" Version="8.29.0" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0-preview1.19506.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-rc.1.20451.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0-preview1.19506.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
15 packages were updated in 2 projects:
`Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.Logging.Debug`, `Polly`, `Microsoft.Extensions.Http`, `Microsoft.Extensions.Http.Polly`, `SendGrid`, `NUnit3TestAdapter`, `Moq`, `FirebaseAdmin`, `MediatR`, `Microsoft.NET.Test.Sdk`, `Microsoft.VisualStudio.Web.CodeGeneration.Design`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.SqlServer` to `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`
`Microsoft.EntityFrameworkCore.SqlServer 5.0.0-rc.1.20451.13` was published at `2020-09-14T14:43:24Z`, 9 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`

[Microsoft.EntityFrameworkCore.SqlServer 5.0.0-rc.1.20451.13 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/5.0.0-rc.1.20451.13)

NuKeeper has generated a major update of `Microsoft.EntityFrameworkCore.Tools` to `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`
`Microsoft.EntityFrameworkCore.Tools 5.0.0-rc.1.20451.13` was published at `2020-09-14T14:43:20Z`, 9 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.EntityFrameworkCore.Tools` `5.0.0-rc.1.20451.13` from `3.1.0-preview1.19506.2`

[Microsoft.EntityFrameworkCore.Tools 5.0.0-rc.1.20451.13 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/5.0.0-rc.1.20451.13)

NuKeeper has generated a major update of `Microsoft.Extensions.Logging.Debug` to `5.0.0-rc.1.20451.14` from `3.1.0-preview1.19506.1`
`Microsoft.Extensions.Logging.Debug 5.0.0-rc.1.20451.14` was published at `2020-09-14T14:44:06Z`, 9 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.Extensions.Logging.Debug` `5.0.0-rc.1.20451.14` from `3.1.0-preview1.19506.1`

[Microsoft.Extensions.Logging.Debug 5.0.0-rc.1.20451.14 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Debug/5.0.0-rc.1.20451.14)

NuKeeper has generated a patch update of `Polly` to `7.2.1` from `7.2.0`
`Polly 7.2.1` was published at `2020-05-02T11:53:40Z`, 4 months ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Polly` `7.2.1` from `7.2.0`

[Polly 7.2.1 on NuGet.org](https://www.nuget.org/packages/Polly/7.2.1)

NuKeeper has generated a patch update of `Microsoft.Extensions.Http` to `3.1.8` from `3.1.3`
`Microsoft.Extensions.Http 3.1.8` was published at `2020-09-08T14:10:37Z`, 15 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.Extensions.Http` `3.1.8` from `3.1.3`

[Microsoft.Extensions.Http 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.8)

NuKeeper has generated a major update of `Microsoft.Extensions.Http.Polly` to `3.1.8` from `2.2.0`
`Microsoft.Extensions.Http.Polly 3.1.8` was published at `2020-09-08T14:11:03Z`, 15 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.Extensions.Http.Polly` `3.1.8` from `2.2.0`

[Microsoft.Extensions.Http.Polly 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/3.1.8)

NuKeeper has generated a minor update of `SendGrid` to `9.21.0` from `9.13.2`
`SendGrid 9.21.0` was published at `2020-08-19T21:35:05Z`, 1 month ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `SendGrid` `9.21.0` from `9.13.2`

[SendGrid 9.21.0 on NuGet.org](https://www.nuget.org/packages/SendGrid/9.21.0)

NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.17.0` from `3.15.1`
`NUnit3TestAdapter 3.17.0` was published at `2020-07-11T19:10:58Z`, 2 months ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE.UnitTests\HelpMyStreetFE.UnitTests.csproj` to `NUnit3TestAdapter` `3.17.0` from `3.15.1`

[NUnit3TestAdapter 3.17.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.17.0)

NuKeeper has generated a patch update of `Moq` to `4.14.5` from `4.14.1`
`Moq 4.14.5` was published at `2020-07-01T16:48:50Z`, 2 months ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE.UnitTests\HelpMyStreetFE.UnitTests.csproj` to `Moq` `4.14.5` from `4.14.1`

[Moq 4.14.5 on NuGet.org](https://www.nuget.org/packages/Moq/4.14.5)

NuKeeper has generated a minor update of `FirebaseAdmin` to `1.16.0` from `1.9.2`
`FirebaseAdmin 1.16.0` was published at `2020-09-09T18:37:08Z`, 13 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `FirebaseAdmin` `1.16.0` from `1.9.2`

[FirebaseAdmin 1.16.0 on NuGet.org](https://www.nuget.org/packages/FirebaseAdmin/1.16.0)

NuKeeper has generated a minor update of `MediatR` to `8.1.0` from `8.0.1`
`MediatR 8.1.0` was published at `2020-07-27T17:49:48Z`, 2 months ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `MediatR` `8.1.0` from `8.0.1`

[MediatR 8.1.0 on NuGet.org](https://www.nuget.org/packages/MediatR/8.1.0)

NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.7.1` from `16.4.0`
`Microsoft.NET.Test.Sdk 16.7.1` was published at `2020-08-20T09:25:54Z`, 1 month ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE.UnitTests\HelpMyStreetFE.UnitTests.csproj` to `Microsoft.NET.Test.Sdk` `16.7.1` from `16.4.0`

[Microsoft.NET.Test.Sdk 16.7.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.7.1)

NuKeeper has generated a patch update of `Microsoft.VisualStudio.Web.CodeGeneration.Design` to `3.1.4` from `3.1.3`
`Microsoft.VisualStudio.Web.CodeGeneration.Design 3.1.4` was published at `2020-08-04T19:15:58Z`, 1 month ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.VisualStudio.Web.CodeGeneration.Design` `3.1.4` from `3.1.3`

[Microsoft.VisualStudio.Web.CodeGeneration.Design 3.1.4 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design/3.1.4)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `3.1.8` from `3.1.3`
`Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8` was published at `2020-09-08T14:09:20Z`, 15 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `3.1.8` from `3.1.3`

[Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` to `3.1.8` from `3.1.3`
`Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 3.1.8` was published at `2020-09-08T14:07:24Z`, 15 days ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` `3.1.8` from `3.1.3`

[Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/3.1.8)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
