### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="1.9.2" />
     <PackageReference Include="HelpMyStreet.Cache" Version="1.1.379" />
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="FirebaseAdmin" Version="1.9.2" />
-    <PackageReference Include="HelpMyStreet.Cache" Version="1.1.363" />
+    <PackageReference Include="HelpMyStreet.Cache" Version="1.1.379" />
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="MediatR" Version="8.0.1" />

--- a/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
+++ b/HelpMyStreetFE/HelpMyStreetFE/HelpMyStreetFE.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="FirebaseAdmin" Version="1.9.2" />
     <PackageReference Include="HelpMyStreet.Cache" Version="1.1.363" />
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.363" />
-    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.363" />
+    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.3" />


### PR DESCRIPTION
3 packages were updated in 1 project:
`HelpMyStreet.Utils`, `HelpMyStreet.Cache`, `HelpMyStreet.Contracts`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `HelpMyStreet.Utils` to `1.1.379` from `1.1.363`
`HelpMyStreet.Utils 1.1.379` was published at `2020-09-23T13:56:34Z`, 2 hours ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.363`

NuKeeper has generated a patch update of `HelpMyStreet.Cache` to `1.1.379` from `1.1.363`
`HelpMyStreet.Cache 1.1.379` was published at `2020-09-23T13:56:22Z`, 2 hours ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `HelpMyStreet.Cache` `1.1.379` from `1.1.363`

NuKeeper has generated a patch update of `HelpMyStreet.Contracts` to `1.1.379` from `1.1.363`
`HelpMyStreet.Contracts 1.1.379` was published at `2020-09-23T13:56:26Z`, 2 hours ago

1 project update:
Updated `HelpMyStreetFE\HelpMyStreetFE\HelpMyStreetFE.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.363`

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
